### PR TITLE
docs: clarify usage instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -356,3 +356,4 @@ Contributions are welcome to Chainlink's source code.
 Please check out our [contributing guidelines](./docs/CONTRIBUTING.md) for more details.
 
 Thank you!
+docs: clarified usage instructions and fixed grammar


### PR DESCRIPTION
Improved clarity in usage instructions in the README. Fixed minor grammar issue. 
Docs only.
